### PR TITLE
Add basic Node test with GitHub CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,19 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+    - run: npm install
+    - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# InspecaoCana
+
+Este repositório contém um aplicativo simples em HTML para inspeção de cana.
+
+## Testes
+
+Os testes utilizam Node.js para verificar se o arquivo `index.html` possui o título correto.
+
+Para executar localmente:
+
+```bash
+npm install
+npm test
+```
+
+Também há um workflow do GitHub Actions que executa `npm test` a cada push ou pull request para o branch `main`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "inspecaocana",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "inspecaocana",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "inspecaocana",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+const assert = require('assert');
+const html = fs.readFileSync('index.html','utf8');
+assert(html.includes('<title>Inspeção de Cana</title>'), 'title not found');
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add Node test for HTML title
- set up GitHub Actions workflow for Node tests
- document testing process

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849a999bc248331bfa3274d21053b7c